### PR TITLE
Remove unnecessary ` _ca_certificates_packages` dict

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,4 @@
 ---
 # vars file for ca_certificates
 
-_ca_certificates_packages:
-  default:
-    - ca-certificates
-
-ca_certificates_packages: "{{ _ca_certificates_packages[ansible_os_family] | default(_ca_certificates_packages['default'] ) }}"
+ca_certificates_packages: ca-certificates


### PR DESCRIPTION
Hi Robert,

I was browsing this repo and noticed this. This is a small change, but cleaner code is always better, so I decided to submit a patch.

Thanks,
Maxwell
